### PR TITLE
replace 'new bytes' with 'skip buffer' to optimize memory usage ...

### DIFF
--- a/TairaLib/src/main/java/com/gotokeep/keep/taira/ByteArrayNode.java
+++ b/TairaLib/src/main/java/com/gotokeep/keep/taira/ByteArrayNode.java
@@ -55,7 +55,7 @@ class ByteArrayNode extends Node {
     @Override
     public void serialize(ByteBuffer buffer, Object value) {
         if (value == null) {
-            buffer.put(new byte[bytes]);
+            buffer.position(buffer.position() + bytes);
             return;
         }
         byte[] byteValue = valueToByteArray(value);
@@ -70,7 +70,7 @@ class ByteArrayNode extends Node {
         buffer.put(byteValue);
         if (remainSize > 0) {
             // fill remains
-            buffer.put(new byte[remainSize]);
+            buffer.position(buffer.position() + remainSize);
         }
     }
 

--- a/TairaLib/src/main/java/com/gotokeep/keep/taira/CollectionNode.java
+++ b/TairaLib/src/main/java/com/gotokeep/keep/taira/CollectionNode.java
@@ -153,7 +153,7 @@ class CollectionNode extends Node {
         // node with length, fill remain empty bytes
         if (length > 0) {
             int memberByteSize = memberNode.evaluateSize(null);
-            buffer.put(new byte[(length - collectionLength) * memberByteSize]);
+            buffer.position(buffer.position() + (length - collectionLength) * memberByteSize);
         }
     }
 

--- a/TairaLib/src/main/java/com/gotokeep/keep/taira/TairaDataNode.java
+++ b/TairaLib/src/main/java/com/gotokeep/keep/taira/TairaDataNode.java
@@ -68,7 +68,7 @@ class TairaDataNode extends Node {
     @Override
     public void serialize(ByteBuffer buffer, Object value) {
         if (value == null) {
-            buffer.put(new byte[evaluateSize(null)]);
+            buffer.position(buffer.position() + evaluateSize(null));
             return;
         }
         for (Node node : children) {


### PR DESCRIPTION
... when serializing